### PR TITLE
Updated c++ from 11 to 14 to support gridlab-d updates

### DIFF
--- a/Dockerfile.gridappsd_base
+++ b/Dockerfile.gridappsd_base
@@ -117,7 +117,7 @@ RUN cd $TEMP_DIR \
     && make install \
     && cd ${TEMP_DIR}/gridlab-d \
     && autoreconf -if \
-    && ./configure --prefix=$GLD_INSTALL --with-fncs=$FNCS_INSTALL --enable-silent-rules 'CFLAGS=-g -O2 -w' 'CXXFLAGS=-g -O2 -w -std=c++11' 'LDFLAGS=-g -O2 -w' \
+    && ./configure --prefix=$GLD_INSTALL --with-fncs=$FNCS_INSTALL --enable-silent-rules 'CFLAGS=-g -O2 -w' 'CXXFLAGS=-g -O2 -w -std=c++14' 'LDFLAGS=-g -O2 -w' \
     && make \
     && make install \
     && cd /tmp \


### PR DESCRIPTION
Updated c++ from 11 to 14 to support gridlab-d updates

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gridappsd/gridappsd-docker-build/26)
<!-- Reviewable:end -->
